### PR TITLE
Update ci.yml

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,123 +1,120 @@
-name: CI
-permissions: {}
-on:
-  workflow_dispatch:
-  pull_request:
-  push:
-    branches:
-      - master
+on: [push]
+
+name: ci
+permissions:
+  contents: read
 
 jobs:
-  build:
-    name: build +${{ matrix.toolchain }} ${{ matrix.flags }}
+  install:
+    name: Install dependencies
     runs-on: ubuntu-latest
-    timeout-minutes: 10
-    permissions:
-      contents: read
-    strategy:
-      fail-fast: false
-      matrix:
-        toolchain: [stable, nightly]
-        flags:
-          - ''
-          - --via-ir
-          - --use solc:0.8.33 --via-ir
-          - --use solc:0.8.33
-          - --use solc:0.8.13 --via-ir
-          - --use solc:0.8.13
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v3
         with:
-          persist-credentials: false
-      - uses: foundry-rs/foundry-toolchain@v1
+          submodules: recursive
+      - uses: actions/setup-node@v1
         with:
-          version: ${{ matrix.toolchain }}
-      - run: forge --version
-      - run: forge build -vvvvv --skip test --deny warnings ${{ matrix.flags }} --contracts 'test/compilation/*'
+          node-version: 18
+      - uses: pnpm/action-setup@v2
+        with:
+          version: 10
+      - uses: actions/cache@master
+        id: pnpm-cache
+        with:
+          path: |
+            node_modules
+            */*/node_modules
+            .pnpm-store
+          key: ${{ runner.os }}-pnpm-${{ hashFiles('**/package.json', '**/pnpm-lock.yaml') }}
+      - run: pnpm install --frozen-lockfile
+        if: ${{ steps.pnpm-cache.outputs.cache-hit != 'true' }}
 
-  test:
+  lint-sol:
+    name: Solidity lint
     runs-on: ubuntu-latest
-    timeout-minutes: 10
-    permissions:
-      contents: read
-    strategy:
-      fail-fast: false
-      matrix:
-        toolchain: [stable, nightly]
+    needs: [install]
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v3
         with:
-          persist-credentials: false
-      - uses: foundry-rs/foundry-toolchain@v1
+          submodules: recursive
+      - uses: actions/setup-node@v1
         with:
-          version: ${{ matrix.toolchain }}
-      - run: forge --version
-      - run: forge test -vvv
+          node-version: 18
+      - uses: pnpm/action-setup@v2
+        with:
+          version: 10
+      - uses: actions/cache@master
+        id: pnpm-cache
+        with:
+          path: |
+            node_modules
+            */*/node_modules
+            .pnpm-store
+          key: ${{ runner.os }}-pnpm-${{ hashFiles('**/package.json', '**/pnpm-lock.yaml') }}
 
-  fmt:
-    runs-on: ubuntu-latest
-    timeout-minutes: 10
-    permissions:
-      contents: read
-    steps:
-      - uses: actions/checkout@v6
+      - name: Install Foundry
+        uses: foundry-rs/foundry-toolchain@v1
         with:
-          persist-credentials: false
-      - uses: foundry-rs/foundry-toolchain@v1
-      - run: forge --version
-      - run: forge fmt --check
+          version: nightly
 
-  typos:
-    runs-on: ubuntu-latest
-    timeout-minutes: 10
-    permissions:
-      contents: read
-    steps:
-      - uses: actions/checkout@v6
-        with:
-          persist-credentials: false
-      - uses: crate-ci/typos@2d0ce569feab1f8752f1dde43cc2f2aa53236e06 # v1
+      - name: Run linting
+        run: pnpm lint:sol
 
-  codeql:
-    name: Analyze (${{ matrix.language }})
+  foundry-tests:
+    name: Foundry tests
     runs-on: ubuntu-latest
-    permissions:
-      security-events: write
-      actions: read
-      contents: read
-    strategy:
-      fail-fast: false
-      matrix:
-        include:
-          - language: actions
-            build-mode: none
+    needs: [install]
     steps:
-      - name: Checkout repository
-        uses: actions/checkout@v6
+      - uses: actions/checkout@v3
         with:
-          persist-credentials: false
-      - name: Initialize CodeQL
-        uses: github/codeql-action/init@v4
+          submodules: recursive
+      - uses: actions/setup-node@v1
         with:
-          languages: ${{ matrix.language }}
-          build-mode: ${{ matrix.build-mode }}
-      - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@v4
+          node-version: 18
+      - uses: pnpm/action-setup@v2
         with:
-          category: "/language:${{matrix.language}}"
+          version: 10
+      - uses: actions/cache@master
+        id: pnpm-cache
+        with:
+          path: |
+            node_modules
+            */*/node_modules
+            .pnpm-store
+          key: ${{ runner.os }}-pnpm-${{ hashFiles('**/package.json', '**/pnpm-lock.yaml') }}
 
-  ci-success:
-    runs-on: ubuntu-latest
-    if: always()
-    needs:
-      - build
-      - test
-      - fmt
-      - typos
-      - codeql
-    timeout-minutes: 10
-    steps:
-      - name: Decide whether the needed jobs succeeded or failed
-        uses: re-actors/alls-green@05ac9388f0aebcb5727afa17fcccfecd6f8ec5fe # release/v1
+      - name: Install Foundry
+        uses: foundry-rs/foundry-toolchain@v1
         with:
-          jobs: ${{ toJSON(needs) }}
+          version: nightly
+
+      - name: Run tests
+        run: FOUNDRY_FUZZ_RUNS=1024 forge test -vvv
+
+  # coverage:
+  #   name: Coverage
+  #   runs-on: ubuntu-latest
+  #   needs: [install]
+  #   steps:
+  #     - uses: actions/checkout@v3
+  #       with:
+  #         submodules: recursive
+  #     - uses: actions/setup-node@v1
+  #       with:
+  #         node-version: 18
+  #     - uses: pnpm/action-setup@v2
+  #       with:
+  #         version: 10
+  #     - uses: actions/cache@master
+  #       id: pnpm-cache
+  #       with:
+  #         path: |
+  #           node_modules
+  #           */*/node_modules
+  #           .pnpm-store
+  #         key: ${{ runner.os }}-pnpm-${{ hashFiles('**/package.json', '**/pnpm-lock.yaml') }}
+  #     - run: pnpm coverage || true
+  #     - name: Coveralls
+  #       uses: coverallsapp/github-action@master
+  #       with:
+  #         github-token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary by Sourcery

Simplify and repurpose the CI workflow to run a Node/pnpm-based pipeline with Foundry tests and Solidity linting on push events.

Build:
- Switch the workflow trigger to run only on push events and rename the workflow to `ci` with read-only contents permissions.

CI:
- Replace the previous multi-matrix Foundry build/test, formatting, typo checking, CodeQL analysis, and aggregated status job with a streamlined pipeline that installs Node/pnpm dependencies, runs Solidity linting via `pnpm lint:sol`, and executes Foundry tests with fuzzing.