### PR TITLE
Update ci.yml

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,7 +26,7 @@ jobs:
             */*/node_modules
             .pnpm-store
           key: ${{ runner.os }}-pnpm-${{ hashFiles('**/package.json', '**/pnpm-lock.yaml') }}
-      - run: pnpm install --frozen-lockfile
+      - run: pnpm install --no-frozen-lockfile
         if: ${{ steps.pnpm-cache.outputs.cache-hit != 'true' }}
 
   lint-sol:


### PR DESCRIPTION
## Summary by Sourcery

CI:
- Update CI workflow to run `pnpm install` with `--no-frozen-lockfile` instead of `--frozen-lockfile` when cache is missed.