### PR TITLE
Revert "Update ci.yml"

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,7 +26,7 @@ jobs:
             */*/node_modules
             .pnpm-store
           key: ${{ runner.os }}-pnpm-${{ hashFiles('**/package.json', '**/pnpm-lock.yaml') }}
-      - run: pnpm install --no-frozen-lockfile
+      - run: pnpm install --frozen-lockfile
         if: ${{ steps.pnpm-cache.outputs.cache-hit != 'true' }}
 
   lint-sol:


### PR DESCRIPTION
Reverts Dargon789/wallet-contracts#36

## Summary by Sourcery

CI:
- Restore pnpm installation in CI to run with --frozen-lockfile instead of --no-frozen-lockfile.