### PR TITLE
Refactor GitHub Actions workflow for tool updates

### DIFF
--- a/.github/workflows/npm.yml
+++ b/.github/workflows/npm.yml
@@ -22,7 +22,6 @@ defaults:
     shell: bash
 
 env:
-  ACTIONS_RUNNER_DEBUG: true
   NPM_CONFIG_PROVENANCE: true
   NPM_REGISTRY_URL: "https://registry.npmjs.org"
 
@@ -32,22 +31,72 @@ jobs:
       contents: read
       actions: read
       id-token: write
-    name: ${{ matrix.os }}-${{ matrix.arch }}
+    name: ${{ matrix.tool }}-${{ matrix.os }}-${{ matrix.arch }}
     runs-on: ubuntu-latest
     strategy:
       max-parallel: 3
       fail-fast: false
       matrix:
         include:
-          - os: linux
+          - tool: forge
+            os: linux
             arch: amd64
-          - os: linux
+          - tool: forge
+            os: linux
             arch: arm64
-          - os: darwin
+          - tool: forge
+            os: darwin
             arch: amd64
-          - os: darwin
+          - tool: forge
+            os: darwin
             arch: arm64
-          - os: win32
+          - tool: forge
+            os: win32
+            arch: amd64
+          - tool: cast
+            os: linux
+            arch: amd64
+          - tool: cast
+            os: linux
+            arch: arm64
+          - tool: cast
+            os: darwin
+            arch: amd64
+          - tool: cast
+            os: darwin
+            arch: arm64
+          - tool: cast
+            os: win32
+            arch: amd64
+          - tool: anvil
+            os: linux
+            arch: amd64
+          - tool: anvil
+            os: linux
+            arch: arm64
+          - tool: anvil
+            os: darwin
+            arch: amd64
+          - tool: anvil
+            os: darwin
+            arch: arm64
+          - tool: anvil
+            os: win32
+            arch: amd64
+          - tool: chisel
+            os: linux
+            arch: amd64
+          - tool: chisel
+            os: linux
+            arch: arm64
+          - tool: chisel
+            os: darwin
+            arch: amd64
+          - tool: chisel
+            os: darwin
+            arch: arm64
+          - tool: chisel
+            os: win32
             arch: amd64
     # Run automatically after a successful 'release' workflow, or manually if a run_id is provided
     if: >-
@@ -59,28 +108,9 @@ jobs:
       RELEASE_VERSION: ${{ steps.release-version.outputs.RELEASE_VERSION }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v5
+        uses: actions/checkout@v6
         with:
           persist-credentials: false
-
-      - name: Setup Bun
-        uses: oven-sh/setup-bun@735343b667d3e6f658f44d0eca948eb6282f2b76 # v2
-        with:
-          bun-version: latest
-
-      - name: Setup Node (for npm publish auth)
-        uses: actions/setup-node@v5
-        with:
-          node-version: "24"
-          registry-url: "https://registry.npmjs.org"
-
-      - name: Install Dependencies
-        working-directory: ./npm
-        run: bun install --frozen-lockfile
-
-      - name: Transpile TS -> JS
-        working-directory: ./npm
-        run: bun run build
 
       - name: Set Isolated Artifact Directory
         id: paths
@@ -96,7 +126,7 @@ jobs:
           ls -la "$ARTIFACT_DIR" || true
 
       - name: Download Release Assets
-        uses: actions/download-artifact@v5
+        uses: actions/download-artifact@v7
         with:
           merge-multiple: true
           # Download all foundry artifacts from the triggering release run
@@ -105,6 +135,47 @@ jobs:
           path: ${{ steps.paths.outputs.artifact_dir }}
           github-token: ${{ secrets.GITHUB_TOKEN }}
           run-id: ${{ github.event.workflow_run.id || inputs.run_id }}
+
+      - name: Validate Downloaded Artifacts
+        env:
+          ARTIFACT_DIR: ${{ steps.paths.outputs.artifact_dir }}
+        run: |
+          set -euo pipefail
+
+          echo "Validating artifacts in: $ARTIFACT_DIR"
+
+          if [[ ! -d "$ARTIFACT_DIR" ]]; then
+            echo "ERROR: Artifact directory does not exist: $ARTIFACT_DIR" >&2
+            exit 1
+          fi
+
+          if ! find "$ARTIFACT_DIR" -mindepth 1 -print -quit | grep -q .; then
+            echo "ERROR: Artifact directory is empty: $ARTIFACT_DIR" >&2
+            exit 1
+          fi
+
+          # Reject files with suspicious paths (absolute paths or parent directory traversals)
+          # Use null-delimited paths to safely handle filenames with newlines or whitespace
+          while IFS= read -r -d '' path; do
+            rel="${path#"$ARTIFACT_DIR"/}"
+            if [[ "$rel" == /* ]] || [[ "$rel" == *".."* ]]; then
+              echo "ERROR: Suspicious artifact path detected: $rel" >&2
+              exit 1
+            fi
+          done < <(find "$ARTIFACT_DIR" -type f -print0)
+
+          echo "Artifact validation completed successfully."
+
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@3d267786b128fe76c2f16a390aa2448b815359f3 # v2
+        with:
+          bun-version: latest
+
+      - name: Setup Node (for npm publish auth)
+        uses: actions/setup-node@v6
+        with:
+          node-version: "24"
+          registry-url: "https://registry.npmjs.org"
 
       - name: Derive RELEASE_VERSION
         id: release-version
@@ -123,15 +194,29 @@ jobs:
 
           # Derive RELEASE_VERSION from any foundry artifact we downloaded
           # Expected names: foundry_<VERSION>_<platform>_<arch>.{tar.gz,zip}
-          first_file=$(ls "$ARTIFACT_DIR"/foundry_* 2>/dev/null | head -n1 || true)
-          if [[ -z "${first_file}" ]]; then
-            echo "No foundry artifacts found to publish" >&2
+          shopt -s nullglob
+          foundry_files=("$ARTIFACT_DIR"/foundry_*)
+          shopt -u nullglob
+
+          if [[ ${#foundry_files[@]} -eq 0 ]]; then
+            echo "No foundry artifacts found to publish in $ARTIFACT_DIR" >&2
             exit 1
           fi
+
+          first_file="${foundry_files[0]}"
           version_part=$(basename "$first_file")
           version_part=${version_part#foundry_}
-          export RELEASE_VERSION=${version_part%%_*}
-          echo "Detected RELEASE_VERSION=$RELEASE_VERSION"
+          RELEASE_VERSION=${version_part%%_*}
+
+          # Validate derived RELEASE_VERSION to mitigate artifact poisoning
+          # Require a sane version format, e.g. 1.2.3 or 1.2.3-beta.1
+          if [[ ! "$RELEASE_VERSION" =~ ^[0-9]+(\.[0-9]+)*(-[0-9A-Za-z.-]+)?$ ]]; then
+            echo "ERROR: Derived RELEASE_VERSION '$RELEASE_VERSION' from artifact '$first_file' is not a valid version" >&2
+            exit 1
+          fi
+
+          export RELEASE_VERSION
+          echo "Detected RELEASE_VERSION=$RELEASE_VERSION from artifact $first_file"
 
           printf 'RELEASE_VERSION=%s\n' "$RELEASE_VERSION" >>"$GITHUB_OUTPUT"
 
@@ -142,34 +227,26 @@ jobs:
           ARTIFACT_DIR: ${{ steps.paths.outputs.artifact_dir }}
         run: |
           set -euo pipefail
-          mkdir -p "$ARTIFACT_DIR/tmp"
 
-          FILE_PREFIX="$ARTIFACT_DIR/foundry_${RELEASE_VERSION}_${{ matrix.os }}_${{ matrix.arch }}"
-          if [[ -f "${FILE_PREFIX}.zip" ]]; then
-            echo "Extracting ${FILE_PREFIX}.zip"
-            if ! command -v unzip >/dev/null 2>&1; then
-              sudo apt-get update -y && sudo apt-get install -y unzip
-            fi
-            unzip -o "${FILE_PREFIX}.zip" -d "$ARTIFACT_DIR/tmp"
-            BIN="$ARTIFACT_DIR/tmp/forge.exe"
-          else
-            echo "Extracting ${FILE_PREFIX}.tar.gz"
-            tar -xzf "${FILE_PREFIX}.tar.gz" -C "$ARTIFACT_DIR/tmp"
-            BIN="$ARTIFACT_DIR/tmp/forge"
-          fi
-
-          echo "Staging binary $BIN into @foundry-rs/forge-${{ matrix.os }}-${{ matrix.arch }}"
-          PLATFORM_NAME=${{ matrix.os }} ARCH=${{ matrix.arch }} FORGE_BIN_PATH="$BIN" bun ./scripts/prepublish.ts
+          bun ./scripts/stage-from-artifact.mjs \
+            --tool '${{ matrix.tool }}' \
+            --platform '${{ matrix.os }}' \
+            --arch '${{ matrix.arch }}' \
+            --release-version "$RELEASE_VERSION" \
+            --artifact-dir "$ARTIFACT_DIR"
 
       - name: Sanity Check Binary
-        env:
-          ARTIFACT_DIR: ${{ steps.paths.outputs.artifact_dir }}
+        working-directory: ./npm
         run: |
           set -euo pipefail
-          PKG_DIR="$ARTIFACT_DIR/@foundry-rs/forge-${{ matrix.os }}-${{ matrix.arch }}"
-          BIN="$PKG_DIR/bin/forge"
-          if [[ "${{ matrix.os }}" == "win32" ]]; then
-            BIN="$PKG_DIR/bin/forge.exe"
+          TOOL='${{ matrix.tool }}'
+          PLATFORM='${{ matrix.os }}'
+          ARCH='${{ matrix.arch }}'
+
+          PKG_DIR="./@foundry-rs/${TOOL}-${PLATFORM}-${ARCH}"
+          BIN="$PKG_DIR/bin/${TOOL}"
+          if [[ "$PLATFORM" == "win32" ]]; then
+            BIN="$PKG_DIR/bin/${TOOL}.exe"
           fi
           echo "Verifying binary at: $BIN"
           ls -la "$BIN"
@@ -184,24 +261,119 @@ jobs:
               exit 1
             fi
           fi
-          
-      # Run automatically after a successful 'release' workflow, or manually if a run_id is provided
+
       - name: Publish ${{ matrix.os }}-${{ matrix.arch }} Binary
-          ARTIFACT_DIR: ${{ steps.paths.outputs.artifact_dir }}
+        working-directory: ./npm
         env:
           PROVENANCE: true
           VERSION_NAME: ${{ steps.release-version.outputs.RELEASE_VERSION }}
           RELEASE_VERSION: ${{ steps.release-version.outputs.RELEASE_VERSION }}
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+          ARTIFACT_DIR: ${{ steps.paths.outputs.artifact_dir }}
         run: |
           set -euo pipefail
 
-          ls -la "$ARTIFACT_DIR/@foundry-rs/forge-${{ matrix.os }}-${{ matrix.arch }}"
+          TOOL='${{ matrix.tool }}'
+          PLATFORM='${{ matrix.os }}'
+          ARCH='${{ matrix.arch }}'
 
-          bun ./scripts/publish.ts "$ARTIFACT_DIR/@foundry-rs/forge-${{ matrix.os }}-${{ matrix.arch }}"
+          # Basic validation of matrix-derived values to avoid path manipulation
+          case "$TOOL" in
+            (*[!a-zA-Z0-9_-]*|'') echo "ERROR: Invalid TOOL value: $TOOL" >&2; exit 1 ;;
+          esac
+          case "$PLATFORM" in
+            (*[!a-zA-Z0-9_-]*|'') echo "ERROR: Invalid PLATFORM value: $PLATFORM" >&2; exit 1 ;;
+          esac
+          case "$ARCH" in
+            (*[!a-zA-Z0-9_-]*|'') echo "ERROR: Invalid ARCH value: $ARCH" >&2; exit 1 ;;
+          esac
 
-          echo "Published @foundry-rs/forge-${{ matrix.os }}-${{ matrix.arch }}"
+          PACKAGE_DIR="./@foundry-rs/${TOOL}-${PLATFORM}-${ARCH}"
+          EXPECTED_PKG_NAME="${TOOL}-${PLATFORM}-${ARCH}"
+
+          # Ensure corresponding artifact directory exists in the isolated artifact dir
+          if [[ -z "${ARTIFACT_DIR:-}" ]]; then
+            echo "ERROR: ARTIFACT_DIR is not set; refusing to publish." >&2
+            exit 1
+          fi
+
+          EXPECTED_ARTIFACT_PATH="${ARTIFACT_DIR}/${EXPECTED_PKG_NAME}"
+          if [[ ! -d "$EXPECTED_ARTIFACT_PATH" ]]; then
+            echo "ERROR: Expected artifact directory not found at: $EXPECTED_ARTIFACT_PATH" >&2
+            exit 1
+          fi
+
+          # Resolve artifact path to an absolute path and ensure it stays within ARTIFACT_DIR
+          ABS_ARTIFACT_PATH="$(realpath "$EXPECTED_ARTIFACT_PATH")"
+          ABS_ARTIFACT_ROOT="$(realpath "$ARTIFACT_DIR")"
+          case "$ABS_ARTIFACT_PATH" in
+            "$ABS_ARTIFACT_ROOT"/*) ;;
+            *)
+              echo "ERROR: Resolved artifact path is outside isolated artifact root:" >&2
+              echo "  ABS_ARTIFACT_PATH=$ABS_ARTIFACT_PATH" >&2
+              echo "  ABS_ARTIFACT_ROOT=$ABS_ARTIFACT_ROOT" >&2
+              exit 1
+              ;;
+          esac
+
+          echo "Preparing to publish package from: $PACKAGE_DIR (artifact: $EXPECTED_ARTIFACT_PATH)"
+
+          if [[ ! -d "$PACKAGE_DIR" ]]; then
+            echo "ERROR: Package directory does not exist: $PACKAGE_DIR" >&2
+            exit 1
+          fi
+
+          # Resolve to an absolute path and ensure it stays within ./@foundry-rs
+          ABS_PACKAGE_DIR="$(realpath "$PACKAGE_DIR")"
+          ABS_EXPECTED_ROOT="$(realpath "./@foundry-rs")"
+          case "$ABS_PACKAGE_DIR" in
+            "$ABS_EXPECTED_ROOT"/*) ;;
+            *)
+              echo "ERROR: Resolved package directory is outside expected root:" >&2
+              echo "  ABS_PACKAGE_DIR=$ABS_PACKAGE_DIR" >&2
+              echo "  ABS_EXPECTED_ROOT=$ABS_EXPECTED_ROOT" >&2
+              exit 1
+              ;;
+          esac
+
+          ls -la "$PACKAGE_DIR"
+
+          # Minimal sanity check: require a package.json before publishing
+          if [[ ! -f "$PACKAGE_DIR/package.json" ]]; then
+            echo "ERROR: package.json not found in $PACKAGE_DIR; refusing to publish." >&2
+            exit 1
+          fi
+
+          # If the artifact also contains a package.json, ensure it matches the source package
+          if [[ -f "$EXPECTED_ARTIFACT_PATH/package.json" ]]; then
+            # Extract name and version from both package.json files using jq if available; fall back to grep/sed
+            if command -v jq >/dev/null 2>&1; then
+              SRC_NAME="$(jq -r '.name // empty' < "$PACKAGE_DIR/package.json")"
+              SRC_VERSION="$(jq -r '.version // empty' < "$PACKAGE_DIR/package.json")"
+              ART_NAME="$(jq -r '.name // empty' < "$EXPECTED_ARTIFACT_PATH/package.json")"
+              ART_VERSION="$(jq -r '.version // empty' < "$EXPECTED_ARTIFACT_PATH/package.json")"
+            else
+              SRC_NAME="$(grep -m1 '"name"' "$PACKAGE_DIR/package.json" | sed -E 's/.*"name"[[:space:]]*:[[:space:]]*"([^"]*)".*/\1/')"
+              SRC_VERSION="$(grep -m1 '"version"' "$PACKAGE_DIR/package.json" | sed -E 's/.*"version"[[:space:]]*:[[:space:]]*"([^"]*)".*/\1/')"
+              ART_NAME="$(grep -m1 '"name"' "$EXPECTED_ARTIFACT_PATH/package.json" | sed -E 's/.*"name"[[:space:]]*:[[:space:]]*"([^"]*)".*/\1/')"
+              ART_VERSION="$(grep -m1 '"version"' "$EXPECTED_ARTIFACT_PATH/package.json" | sed -E 's/.*"version"[[:space:]]*:[[:space:]]*"([^"]*)".*/\1/')"
+            fi
+
+            if [[ -n "$SRC_NAME" && -n "$ART_NAME" && "$SRC_NAME" != "$ART_NAME" ]]; then
+              echo "ERROR: Artifact package name ($ART_NAME) does not match source package name ($SRC_NAME); refusing to publish." >&2
+              exit 1
+            fi
+
+            if [[ -n "$SRC_VERSION" && -n "$ART_VERSION" && "$SRC_VERSION" != "$ART_VERSION" ]]; then
+              echo "ERROR: Artifact package version ($ART_VERSION) does not match source package version ($SRC_VERSION); refusing to publish." >&2
+              exit 1
+            fi
+          fi
+
+          bun ./scripts/publish.mjs "$PACKAGE_DIR"
+
+          echo "Published @foundry-rs/${TOOL}-${PLATFORM}-${ARCH}"
 
   publish-meta:
     permissions:
@@ -217,17 +389,17 @@ jobs:
       RELEASE_VERSION: ${{ needs.publish-arch.outputs.RELEASE_VERSION }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v5
+        uses: actions/checkout@v6
         with:
           persist-credentials: false
 
       - name: Setup Bun
-        uses: oven-sh/setup-bun@735343b667d3e6f658f44d0eca948eb6282f2b76 # v2
+        uses: oven-sh/setup-bun@3d267786b128fe76c2f16a390aa2448b815359f3 # v2
         with:
           bun-version: latest
 
       - name: Setup Node (for npm publish auth)
-        uses: actions/setup-node@v5
+        uses: actions/setup-node@v6
         with:
           node-version: "24"
           registry-url: "https://registry.npmjs.org"
@@ -236,13 +408,15 @@ jobs:
         working-directory: ./npm
         run: bun install --frozen-lockfile
 
-      - name: Transpile TS -> JS
+      - name: Typecheck
         working-directory: ./npm
-        run: bun run build
+        run: bun tsc --project tsconfig.json --noEmit
 
-      - name: Publish Meta
+      - name: Publish Meta Packages
         working-directory: ./npm
-        run: bun run ./scripts/publish.ts ./@foundry-rs/forge
+        run: |
+          set -euo pipefail
+          bun ./scripts/publish-meta.mjs --release-version "$RELEASE_VERSION"
         env:
           PROVENANCE: true
           VERSION_NAME: ${{ env.RELEASE_VERSION }}


### PR DESCRIPTION
Updated GitHub Actions workflow to include new tools and improve artifact validation. Changed Node and Bun setup actions to their latest versions and added type checking step. https://github.com/Dargon789/foundry/commit/8413eb853ca0eb7dc39cf8980c47726f9dfd843a

## Summary by Sourcery

Refactor the npm publish GitHub Actions workflow to support multiple tools, strengthen artifact and path validation, and modernize supporting scripts and actions.

New Features:
- Add matrix support for publishing forge, cast, anvil, and chisel binaries across OS and architectures.
- Introduce dedicated staging and publish scripts for tool artifacts and meta packages using new .mjs entrypoints.

Enhancements:
- Upgrade checkout, setup-node, and download-artifact actions to their latest major versions.
- Add comprehensive validation of downloaded artifacts, derived release version, and publish paths to mitigate artifact poisoning and path traversal risks.
- Refactor binary staging and sanity checks to use a generic tool/platform/arch scheme and isolated artifact directories.
- Replace the previous build step in the meta publish job with a type-check-only step for faster feedback and stricter typing.

CI:
- Tighten GitHub Actions workflow security by validating matrix inputs, ensuring directories remain within expected roots, and verifying package.json metadata before publishing.