### PR TITLE
Update ci.yml

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,7 +26,7 @@ jobs:
             */*/node_modules
             .pnpm-store
           key: ${{ runner.os }}-pnpm-${{ hashFiles('**/package.json', '**/pnpm-lock.yaml') }}
-      - run:  pnpm install --no-frozen-lockfile 
+      - run:  pnpm install --frozen-lockfile 
         continue-on-error: false
         if: ${{ steps.pnpm-cache.outputs.cache-hit != 'true' }}
 


### PR DESCRIPTION
## Summary by Sourcery

CI:
- Update the CI workflow to use `pnpm install --frozen-lockfile` instead of `--no-frozen-lockfile` on cache misses to ensure lockfile consistency.