### PR TITLE
Potential fix for code scanning alert no. 15: Artifact poisoning

### DIFF
--- a/.github/workflows/npm.yml
+++ b/.github/workflows/npm.yml
@@ -358,6 +358,15 @@ jobs:
             exit 1
           fi
 
+          # Ensure ARTIFACT_DIR is exactly the isolated directory we created earlier
+          EXPECTED_ARTIFACT_ROOT="${RUNNER_TEMP%/}/foundry_artifacts"
+          ABS_ARTIFACT_DIR="$(realpath "$ARTIFACT_DIR")"
+          ABS_EXPECTED_ARTIFACT_ROOT="$(realpath "$EXPECTED_ARTIFACT_ROOT")"
+          if [[ "$ABS_ARTIFACT_DIR" != "$ABS_EXPECTED_ARTIFACT_ROOT" ]]; then
+            echo "ERROR: ARTIFACT_DIR ($ABS_ARTIFACT_DIR) does not match expected isolated artifact root ($ABS_EXPECTED_ARTIFACT_ROOT); refusing to publish." >&2
+            exit 1
+          fi
+
           EXPECTED_ARTIFACT_PATH="${ARTIFACT_DIR}/${EXPECTED_PKG_NAME}"
           if [[ ! -d "$EXPECTED_ARTIFACT_PATH" ]]; then
             echo "ERROR: Expected artifact directory not found at: $EXPECTED_ARTIFACT_PATH" >&2


### PR DESCRIPTION
Potential fix for [https://github.com/Dargon789/wallet-contracts/security/code-scanning/15](https://github.com/Dargon789/wallet-contracts/security/code-scanning/15)

At a high level, the fix is to further constrain how data that depends on downloaded artifacts can affect the publishing step, ensuring that no paths or commands derived from artifact contents are ever executed or used as working directories. The artifacts should remain in an isolated temp directory, be treated as read-only data, and only be used for consistency checks against trusted repository contents.

In this particular script, the main taint concern is that `EXPECTED_ARTIFACT_PATH` is derived from `ARTIFACT_DIR` (which comes from the download step) and `EXPECTED_PKG_NAME` (from matrix values), and then is used in checks and `jq`/`grep` commands. While those uses are already constrained, CodeQL still associates taint flow with the entire `run: |` block. To harden and clarify the trust boundary without changing functionality, we can: (1) ensure that `ARTIFACT_DIR` itself cannot be attacker-controlled by refusing to run unless it equals the expected `$RUNNER_TEMP/foundry_artifacts` path; and (2) ensure that no files from `EXPECTED_ARTIFACT_PATH` are ever executed or used as script inputs (only read as JSON data). Point (2) is already true; point (1) is what we’ll add. Concretely, in the “Publish … Binary” shell script, right after verifying that `ARTIFACT_DIR` is set, we add a check that its resolved absolute path equals the known safe directory (based on `$RUNNER_TEMP` and the `Set Isolated Artifact Directory` step), and abort otherwise. This guarantees that even if an attacker managed to tamper with `ARTIFACT_DIR` (e.g., via environment injection), the job will not proceed. This additional invariant makes it easier for CodeQL to reason that the artifacts are confined to a non-privileged, controlled directory and that no artifact path can be used to overwrite or execute code.

No new methods, imports, or external actions are required; we just extend the existing bash script inside the `Publish ... Binary` step to add this strict check on `ARTIFACT_DIR` before any further use.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._

## Summary by Sourcery

CI:
- Add a safety check in the npm workflow to verify ARTIFACT_DIR resolves to the predetermined isolated artifact root and abort if it does not.