### PR TITLE
Potential fix for code scanning alert no. 14: Artifact poisoning

### DIFF
--- a/.github/workflows/npm.yml
+++ b/.github/workflows/npm.yml
@@ -150,6 +150,34 @@ jobs:
           fi
 
           if [[ ! -d "$ARTIFACT_DIR" ]]; then
+            echo "ERROR: ARTIFACT_DIR does not exist or is not a directory: $ARTIFACT_DIR" >&2
+            exit 1
+          fi
+
+          # Ensure the artifact directory is not empty
+          if ! find "$ARTIFACT_DIR" -mindepth 1 -print -quit | grep -q .; then
+            echo "ERROR: No files were downloaded into ARTIFACT_DIR ($ARTIFACT_DIR)" >&2
+            exit 1
+          fi
+
+          # Reject any symlinks or path-escaping entries inside the artifact directory
+          while IFS= read -r entry; do
+            if [[ -L "$entry" ]]; then
+              echo "ERROR: Symlink found in artifact directory: $entry" >&2
+              exit 1
+            fi
+
+            real_entry="$(realpath "$entry")"
+            case "$real_entry" in
+              "$ARTIFACT_DIR"/*) ;;
+              *)
+                echo "ERROR: Artifact entry escapes ARTIFACT_DIR: $entry -> $real_entry" >&2
+                exit 1
+                ;;
+            esac
+          done < <(find "$ARTIFACT_DIR" -mindepth 1 -maxdepth 10 -print)
+
+          if [[ ! -d "$ARTIFACT_DIR" ]]; then
             echo "ERROR: Artifact directory does not exist: $ARTIFACT_DIR" >&2
             exit 1
           fi


### PR DESCRIPTION
Potential fix for [https://github.com/Dargon789/wallet-contracts/security/code-scanning/14](https://github.com/Dargon789/wallet-contracts/security/code-scanning/14)

General approach: ensure that all downloaded artifacts are treated as untrusted, remain confined to an isolated directory, and are validated before being consumed by `stage-from-artifact.mjs`. Specifically, we should (1) ensure that the artifact directory is not empty, (2) reject symlinks and files that attempt path traversal outside the artifact directory, and (3) optionally constrain file types to expected patterns. This reduces the chance that a poisoned artifact can inject or override unexpected files that the staging script might consume.

Best concrete fix here: extend the existing `Validate Downloaded Artifacts` step so it performs stronger checks on the contents of `$ARTIFACT_DIR`. We can safely add shell logic there without changing subsequent steps’ observable behavior, as long as validation passes for legitimate artifacts. The new checks will: error if the directory is empty; walk the tree with `find`; for each entry, reject symlinks; and verify that each path remains under `$ARTIFACT_DIR` after `realpath` (defending against crafted symlinks or weird path constructs). This addresses CodeQL’s artifact poisoning concern without touching the later `Stage Binary Into Package` step or changing its interface.

Concretely, in `.github/workflows/npm.yml`:
- Modify the `Validate Downloaded Artifacts` step (lines ~139–151 and following) to include:
  - An assertion that `$ARTIFACT_DIR` exists and is non-empty.
  - A loop using `find "$ARTIFACT_DIR" -mindepth 1` to inspect all files/dirs.
  - Rejection of any symlink (`-L`).
  - A `realpath` check that ensures every entry is still within `$ARTIFACT_DIR`.
- We do not need to change the `Stage Binary Into Package` step or its `run:` line; it will now only be reached if artifacts pass validation.

No new imports or external actions are required; this is pure shell in an existing `run:` block.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._

## Summary by Sourcery

Bug Fixes:
- Validate that the downloaded artifact directory exists, is non-empty, and contains no symlinks or entries that escape the artifact directory in the npm workflow.