### PR TITLE
Update ci.yml

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -59,7 +59,7 @@ jobs:
             */*/node_modules
           key: ${{ runner.os }}-lerna-${{ hashFiles('**/package.json', '**/yarn.lock') }}
       - run: yarn lint:ts
-
+      - run: yarn run test -o --watch
   lint-sol:
     name: Solidity lint
     runs-on: ubuntu-latest
@@ -77,7 +77,7 @@ jobs:
             */*/node_modules
           key: ${{ runner.os }}-lerna-${{ hashFiles('**/package.json', '**/yarn.lock') }}
       - run: yarn lint:sol
-
+      - run: yarn run lint:sol -o --watch
   test:
     name: Test contracts
     runs-on: ubuntu-latest
@@ -95,7 +95,8 @@ jobs:
             */*/node_modules
           key: ${{ runner.os }}-lerna-${{ hashFiles('**/package.json', '**/yarn.lock') }}
       - run: yarn build
-      - run: yarn test
+      - run: yarn test -o --watch 
+      continue-on-error: true
 
   coverage:
     name: Coverage


### PR DESCRIPTION
## Summary by Sourcery

Update CI workflow test and lint jobs to run watch-mode commands and allow contract tests to continue on error.

CI:
- Run TypeScript lint job tests in watch mode in the CI workflow.
- Run Solidity lint job in watch mode in the CI workflow.
- Allow the contract test job to continue on error while running tests in watch mode.