### PR TITLE
Update ci.yml

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,7 +25,7 @@ jobs:
       - run: npm install --global yarn
       - run: yarn install --network-concurrency 1
         if: ${{ steps.yarn-cache.outputs.cache-hit != 'true' }}
-        continue-on-error: true
+  
   benchmark:
     name: Benchmark
     runs-on: ubuntu-latest


### PR DESCRIPTION
npm install -g corepack & corepack enable can use npm pnpm yarn group

## Summary by Sourcery

CI:
- Remove the `continue-on-error` flag from the yarn install step in the CI workflow so installation failures cause the job to fail.