### PR TITLE
Update ci.yml

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,7 @@ jobs:
       - uses: actions/checkout@v1
       - uses: actions/setup-node@v1
         with:
-          node-version: 18.15
+          node-version: 22
       - uses: actions/cache@master
         id: yarn-cache
         # yarn self-update


### PR DESCRIPTION
## Summary by Sourcery

CI:
- Bump the Node.js version in the GitHub Actions CI workflow from 18.15 to 22.