### PR TITLE
Potential fix for code scanning alert no. 15: Artifact poisoning

### DIFF
--- a/.github/workflows/npm.yml
+++ b/.github/workflows/npm.yml
@@ -428,37 +428,52 @@ jobs:
 
           ls -la "$PACKAGE_DIR"
 
-          # Minimal sanity check: require a package.json before publishing
+          # Minimal sanity check: require a package.json in the source package before publishing
           if [[ ! -f "$PACKAGE_DIR/package.json" ]]; then
             echo "ERROR: package.json not found in $PACKAGE_DIR; refusing to publish." >&2
             exit 1
           fi
 
-          # If the artifact also contains a package.json, ensure it matches the source package
-          if [[ -f "$EXPECTED_ARTIFACT_PATH/package.json" ]]; then
-            # Extract name and version from both package.json files using jq if available; fall back to grep/sed
-            if command -v jq >/dev/null 2>&1; then
-              SRC_NAME="$(jq -r '.name // empty' < "$PACKAGE_DIR/package.json")"
-              SRC_VERSION="$(jq -r '.version // empty' < "$PACKAGE_DIR/package.json")"
-              ART_NAME="$(jq -r '.name // empty' < "$EXPECTED_ARTIFACT_PATH/package.json")"
-              ART_VERSION="$(jq -r '.version // empty' < "$EXPECTED_ARTIFACT_PATH/package.json")"
-            else
-              SRC_NAME="$(grep -m1 '"name"' "$PACKAGE_DIR/package.json" | sed -E 's/.*"name"[[:space:]]*:[[:space:]]*"([^"]*)".*/\1/')"
-              SRC_VERSION="$(grep -m1 '"version"' "$PACKAGE_DIR/package.json" | sed -E 's/.*"version"[[:space:]]*:[[:space:]]*"([^"]*)".*/\1/')"
-              ART_NAME="$(grep -m1 '"name"' "$EXPECTED_ARTIFACT_PATH/package.json" | sed -E 's/.*"name"[[:space:]]*:[[:space:]]*"([^"]*)".*/\1/')"
-              ART_VERSION="$(grep -m1 '"version"' "$EXPECTED_ARTIFACT_PATH/package.json" | sed -E 's/.*"version"[[:space:]]*:[[:space:]]*"([^"]*)".*/\1/')"
-            fi
-
-            if [[ -n "$SRC_NAME" && -n "$ART_NAME" && "$SRC_NAME" != "$ART_NAME" ]]; then
-              echo "ERROR: Artifact package name ($ART_NAME) does not match source package name ($SRC_NAME); refusing to publish." >&2
-              exit 1
-            fi
-
-            if [[ -n "$SRC_VERSION" && -n "$ART_VERSION" && "$SRC_VERSION" != "$ART_VERSION" ]]; then
-              echo "ERROR: Artifact package version ($ART_VERSION) does not match source package version ($SRC_VERSION); refusing to publish." >&2
-              exit 1
-            fi
+          # Require that the artifact also contains a package.json and ensure it matches the source package
+          if [[ ! -f "$EXPECTED_ARTIFACT_PATH/package.json" ]]; then
+            echo "ERROR: package.json not found in artifact at $EXPECTED_ARTIFACT_PATH; refusing to publish from potentially poisoned artifact." >&2
+            exit 1
           fi
+
+          # Extract name and version from both package.json files using jq if available; fall back to grep/sed
+          if command -v jq >/dev/null 2>&1; then
+            SRC_NAME="$(jq -r '.name // empty' < "$PACKAGE_DIR/package.json")"
+            SRC_VERSION="$(jq -r '.version // empty' < "$PACKAGE_DIR/package.json")"
+            ART_NAME="$(jq -r '.name // empty' < "$EXPECTED_ARTIFACT_PATH/package.json")"
+            ART_VERSION="$(jq -r '.version // empty' < "$EXPECTED_ARTIFACT_PATH/package.json")"
+          else
+            SRC_NAME="$(grep -m1 '"name"' "$PACKAGE_DIR/package.json" | sed -E 's/.*"name"[[:space:]]*:[[:space:]]*"([^"]*)".*/\1/')"
+            SRC_VERSION="$(grep -m1 '"version"' "$PACKAGE_DIR/package.json" | sed -E 's/.*"version"[[:space:]]*:[[:space:]]*"([^"]*)".*/\1/')"
+            ART_NAME="$(grep -m1 '"name"' "$EXPECTED_ARTIFACT_PATH/package.json" | sed -E 's/.*"name"[[:space:]]*:[[:space:]]*"([^"]*)".*/\1/')"
+            ART_VERSION="$(grep -m1 '"version"' "$EXPECTED_ARTIFACT_PATH/package.json" | sed -E 's/.*"version"[[:space:]]*:[[:space:]]*"([^"]*)".*/\1/')"
+          fi
+
+          if [[ -z "$SRC_NAME" || -z "$ART_NAME" ]]; then
+            echo "ERROR: Unable to determine package name from source or artifact package.json; refusing to publish." >&2
+            exit 1
+          fi
+
+          if [[ "$SRC_NAME" != "$ART_NAME" ]]; then
+            echo "ERROR: Artifact package name ($ART_NAME) does not match source package name ($SRC_NAME); refusing to publish." >&2
+            exit 1
+          fi
+
+          if [[ -z "$SRC_VERSION" || -z "$ART_VERSION" ]]; then
+            echo "ERROR: Unable to determine package version from source or artifact package.json; refusing to publish." >&2
+            exit 1
+          fi
+
+          if [[ "$SRC_VERSION" != "$ART_VERSION" ]]; then
+            echo "ERROR: Artifact package version ($ART_VERSION) does not match source package version ($SRC_VERSION); refusing to publish." >&2
+            exit 1
+          fi
+
+          echo "Artifact package.json matches source package.json; proceeding to publish from source directory: $PACKAGE_DIR"
 
           bun ./scripts/publish.mjs "$PACKAGE_DIR"
 


### PR DESCRIPTION
Potential fix for [https://github.com/Dargon789/wallet-contracts/security/code-scanning/15](https://github.com/Dargon789/wallet-contracts/security/code-scanning/15)

General approach: keep treating downloaded artifacts as untrusted and ensure that no unvalidated data from them affects privileged operations. In this workflow, that primarily means (a) strictly constraining where artifacts are extracted, (b) strictly constraining which artifact subdirectory is used for a given matrix combination, and (c) validating that the artifact contents structurally match the expected package before invoking the publish script.

The workflow already does (a) and most of (b). The safest incremental improvement that addresses CodeQL’s concerns without changing intended functionality is to further validate the artifact content before publishing, and to add an explicit structural check that the artifact directory actually contains the expected files from the source package (rather than just trusting that the directory exists and optionally checking `package.json`). Concretely:

- Require that the artifact for a given matrix entry actually contains a `package.json` file, and that it matches the source `package.json` `name` and `version` as already implemented. If it is missing, fail instead of silently proceeding.
- Optionally, verify that the artifact directory has at least some expected files (e.g. `package.json` and `README` or `dist` contents), but to avoid assumptions about structure we’ll stick to enforcing the presence and consistency of `package.json`, which is already the authoritative definition of what is being published.
- Add an explicit log message clarifying that `bun ./scripts/publish.mjs` operates on the repository package directory (`$PACKAGE_DIR`) and *not* directly on the artifact directory; the artifact is only used for cross-checking. This doesn’t change behavior but documents the trust boundary for humans and tools.

The only concrete code change needed in the shown snippet is to make the `package.json` check on the artifact mandatory (rather than optional) and fail if the artifact doesn’t contain `package.json`. This ensures that an attacker cannot slip in a mismatched or malformed artifact directory that bypasses the name/version comparison. All edits are in `.github/workflows/npm.yml` within the existing `Publish ... Binary` step’s bash script.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._

## Summary by Sourcery

Tighten npm publish workflow validation to treat downloaded artifacts as untrusted and prevent publishing from mismatched or malformed artifacts.

Bug Fixes:
- Require that the expected artifact directory contains a package.json before publishing and fail otherwise to mitigate artifact poisoning risk.
- Enforce that package name and version are present and identical between source and artifact package.json files, aborting the publish step on any mismatch or missing values.

Enhancements:
- Clarify logging around successful package.json validation before invoking the publish script to make the trust boundary explicit.