### PR TITLE
Potential fix for code scanning alert no. 14: Artifact poisoning

### DIFF
--- a/.github/workflows/npm.yml
+++ b/.github/workflows/npm.yml
@@ -125,6 +125,18 @@ jobs:
           mkdir -p "$ARTIFACT_DIR"
           ls -la "$ARTIFACT_DIR" || true
 
+      - name: Verify Trusted Artifact Source
+        run: |
+          set -euo pipefail
+          if [[ "${{ github.event_name }}" != "workflow_run" ]]; then
+            echo "ERROR: Artifact download is only allowed from workflow_run triggers." >&2
+            exit 1
+          fi
+          if [[ -z "${{ github.event.workflow_run.id }}" ]]; then
+            echo "ERROR: Missing workflow_run.id for artifact download." >&2
+            exit 1
+          fi
+
       - name: Download Release Assets
         uses: actions/download-artifact@v7
         with:
@@ -134,7 +146,7 @@ jobs:
           # Extract artifacts into an isolated temp directory, not the workspace
           path: ${{ steps.paths.outputs.artifact_dir }}
           github-token: ${{ secrets.GITHUB_TOKEN }}
-          run-id: ${{ github.event.workflow_run.id || inputs.run_id }}
+          run-id: ${{ github.event.workflow_run.id }}
 
       - name: Validate Downloaded Artifacts
         env:


### PR DESCRIPTION
Potential fix for [https://github.com/Dargon789/wallet-contracts/security/code-scanning/14](https://github.com/Dargon789/wallet-contracts/security/code-scanning/14)

General fix: constrain artifact provenance so only trusted workflow-run context can supply artifacts, and block manual/untrusted `run_id`-driven artifact ingestion for publish paths. Keep isolated extraction and validation, but ensure the download source itself is trusted.

Best single fix in this file: remove `workflow_dispatch` input-based run selection from the artifact download and fail fast unless the workflow is triggered by `workflow_run` for the expected upstream workflow. Concretely:
- In `.github/workflows/npm.yml`, edit the `Download Release Assets` step so `run-id` is only `${{ github.event.workflow_run.id }}`.
- Add a guard step just before download that checks event type is `workflow_run` and that run id is present; fail otherwise.  
This preserves existing behavior for normal release-triggered publishes while eliminating the attacker-controlled `run_id` path that CodeQL marks as tainted.

No new imports/dependencies are needed (YAML workflow-only change).


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
