### PR TITLE
Potential fix for code scanning alert no. 15: Artifact poisoning

### DIFF
--- a/.github/workflows/npm.yml
+++ b/.github/workflows/npm.yml
@@ -125,6 +125,21 @@ jobs:
           mkdir -p "$ARTIFACT_DIR"
           ls -la "$ARTIFACT_DIR" || true
 
+      - name: Validate workflow_run trust before downloading artifacts
+        if: ${{ github.event_name == 'workflow_run' }}
+        run: |
+          set -euo pipefail
+
+          if [[ "${{ github.event.workflow_run.conclusion }}" != "success" ]]; then
+            echo "ERROR: Refusing to use artifacts from non-success workflow_run conclusion: ${{ github.event.workflow_run.conclusion }}" >&2
+            exit 1
+          fi
+
+          if [[ "${{ github.event.workflow_run.head_repository.full_name }}" != "${{ github.repository }}" ]]; then
+            echo "ERROR: Refusing to use artifacts from external repository: ${{ github.event.workflow_run.head_repository.full_name }}" >&2
+            exit 1
+          fi
+
       - name: Download Release Assets
         uses: actions/download-artifact@v7
         with:


### PR DESCRIPTION
Potential fix for [https://github.com/Dargon789/wallet-contracts/security/code-scanning/15](https://github.com/Dargon789/wallet-contracts/security/code-scanning/15)

To fix this without changing intended functionality, add a **pre-download trust validation step** in `.github/workflows/npm.yml` (inside `publish-arch` steps, before `Download Release Assets`) that fails unless the triggering `workflow_run` is successful and from the same repository. This prevents consuming artifacts from untrusted or unexpected runs, complements your existing isolated extraction/path validation, and addresses all alert variants in one place because the taint source is blocked early.

Best concrete change:
- In `publish-arch` job, after `Prepare Isolated Artifact Directory` and before `Download Release Assets`, add a step:
  - Verify `github.event_name`/`github.event.workflow_run` context as applicable.
  - Require `github.event.workflow_run.conclusion == 'success'`.
  - Require `github.event.workflow_run.head_repository.full_name == github.repository`.
  - Exit non-zero if checks fail.

No new imports/dependencies are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._

## Summary by Sourcery

CI:
- Add a workflow_run gate in the npm publish workflow that rejects artifacts from unsuccessful runs or external repositories to mitigate artifact poisoning risk.