### PR TITLE
Potential fix for code scanning alert no. 15: Artifact poisoning

### DIFF
--- a/.github/workflows/npm.yml
+++ b/.github/workflows/npm.yml
@@ -140,6 +140,31 @@ jobs:
             exit 1
           fi
 
+      - name: Resolve trusted run id for artifact download
+        id: trusted-run
+        run: |
+          set -euo pipefail
+
+          if [[ "${{ github.event_name }}" == "workflow_run" ]]; then
+            RUN_ID="${{ github.event.workflow_run.id }}"
+          elif [[ "${{ github.event_name }}" == "workflow_dispatch" ]]; then
+            RUN_ID="${{ inputs.run_id }}"
+            if [[ -z "${RUN_ID}" ]]; then
+              echo "ERROR: workflow_dispatch requires inputs.run_id to be set." >&2
+              exit 1
+            fi
+          else
+            echo "ERROR: Unsupported event for artifact download: ${{ github.event_name }}" >&2
+            exit 1
+          fi
+
+          if [[ ! "$RUN_ID" =~ ^[0-9]+$ ]]; then
+            echo "ERROR: Invalid run id: $RUN_ID" >&2
+            exit 1
+          fi
+
+          printf 'run_id=%s\n' "$RUN_ID" >> "$GITHUB_OUTPUT"
+
       - name: Download Release Assets
         uses: actions/download-artifact@v7
         with:
@@ -148,7 +173,7 @@ jobs:
           # Extract artifacts into an isolated temp directory, not the workspace
           path: ${{ steps.paths.outputs.artifact_dir }}
           github-token: ${{ secrets.GITHUB_TOKEN }}
-          run-id: ${{ github.event.workflow_run.id }}
+          run-id: ${{ steps.trusted-run.outputs.run_id }}
 
       - name: Validate Downloaded Artifacts
         env:


### PR DESCRIPTION
Potential fix for [https://github.com/Dargon789/wallet-contracts/security/code-scanning/15](https://github.com/Dargon789/wallet-contracts/security/code-scanning/15)

General fix: ensure artifacts are only downloaded from a run ID that is explicitly selected from a trusted source per trigger type, and fail closed when no trusted run-id is available. Keep artifact extraction in isolated temp directory and preserve existing validation.

Best concrete fix in `.github/workflows/npm.yml`:
1. Add a step before download to compute and validate a single `trusted_run_id` output:
   - For `workflow_run`: require success and same repository (already present), then use `github.event.workflow_run.id`.
   - For `workflow_dispatch`: require `inputs.run_id` to be non-empty and numeric-only.
   - Otherwise fail.
2. Update `Download Release Assets` to use `run-id: ${{ steps.trusted-run.outputs.run_id }}` instead of directly using `github.event.workflow_run.id`.

This resolves the taint flow at source and should address all alert variants at this sink without changing functionality.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._

## Summary by Sourcery

Harden artifact downloads in the npm workflow by resolving and validating a trusted run ID before fetching artifacts, and using that validated ID for the download step.

CI:
- Add a dedicated step in the npm workflow to determine a trusted run ID based on the trigger type, validating presence and numeric format.
- Update the artifact download step to use the validated trusted run ID instead of reading directly from the workflow_run event.