### PR TITLE
Refactor CircleCI config for testing workflow

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,24 +1,22 @@
-# Use the latest 2.1 version of CircleCI pipeline process engine.
-# See: https://circleci.com/docs/configuration-reference
-
 version: 2.1
-executors:
-  my-custom-executor:
-    docker:
-      - image: cimg/base:stable
-        auth:
-          # ensure you have first added these secrets
-          # visit app.circleci.com/settings/project/github/Dargon789/hardhat-project/environment-variables
-          username: $DOCKER_HUB_USER
-          password: $DOCKER_HUB_PASSWORD
+ 
 jobs:
-  web3-defi-game-project-:
-
-    executor: my-custom-executor
+  test:
+    docker:
+      - image: ghcr.io/foundry-rs/foundry:latest
     steps:
       - checkout
-
+      - run:
+          name: Install submodules
+          command: git submodule update --init --recursive
+      - run:
+          name: Build
+          command: forge build
+      - run:
+          name: Test
+          command: forge test -vvv
+ 
 workflows:
-  my-custom-workflow:
+  main:
     jobs:
-      - web3-defi-game-project-
+      - test


### PR DESCRIPTION
## Description

_Concise description of proposed changes_

## Additional Information

- [ ] I read the [contributing docs](/wagmi-dev/wagmi/blob/main/.github/CONTRIBUTING.md) (if this is your first contribution)

Your ENS/address:

## Summary by Sourcery

Refactor the CircleCI configuration to use a single Foundry-based test job and streamlined workflow naming.

CI:
- Replace the custom executor and job with a single `test` job using the Foundry Docker image that checks out the repo, initializes submodules, and runs Forge build and tests.
- Simplify the workflow configuration to a single `main` workflow that runs the new `test` job.