### PR TITLE
Update defender-for-devops.yml

### DIFF
--- a/.github/workflows/defender-for-devops.yml
+++ b/.github/workflows/defender-for-devops.yml
@@ -2,16 +2,12 @@
 # They are provided by a third-party and are governed by
 # separate terms of service, privacy policy, and support
 # documentation.
-#
 # Microsoft Security DevOps (MSDO) is a command line application which integrates static analysis tools into the development cycle.
 # MSDO installs, configures and runs the latest versions of static analysis tools
 # (including, but not limited to, SDL/security and compliance tools).
-#
 # The Microsoft Security DevOps action is currently in beta and runs on the windows-latest queue,
 # as well as Windows self hosted agents. ubuntu-latest support coming soon.
-#
 # For more information about the action , check out https://github.com/microsoft/security-devops-action
-#
 # Please note this workflow do not integrate your GitHub Org with Microsoft Defender For DevOps. You have to create an integration
 # and provide permission before this can report data back to azure.
 # Read the official documentation here : https://learn.microsoft.com/en-us/azure/defender-for-cloud/quickstart-onboard-github
@@ -23,9 +19,9 @@ permissions:
 
 on:
   push:
-    branches: [ "main" ]
+    branches: [ "master" ]
   pull_request:
-    branches: [ "main" ]
+    branches: [ "master" ]
   schedule:
     - cron: '23 8 * * 6'
 


### PR DESCRIPTION
## Description

_Concise description of proposed changes_

## Additional Information

- [ ] I read the [contributing docs](/wagmi-dev/wagmi/blob/main/.github/CONTRIBUTING.md) (if this is your first contribution)

Your ENS/address:

## Summary by Sourcery

Update the Defender for DevOps GitHub Actions workflow to run on the master branch instead of main and clean up redundant comments.

Enhancements:
- Switch the workflow trigger branches from main to master for both push and pull_request events.
- Remove redundant comment lines from the Defender for DevOps workflow header.

CI:
- Adjust CI workflow triggers to align with the repository's master branch naming.